### PR TITLE
refactor

### DIFF
--- a/srcs/IOMultiplexer/IOMultiplexer.cpp
+++ b/srcs/IOMultiplexer/IOMultiplexer.cpp
@@ -426,6 +426,7 @@ Result<int, std::string> Select::get_io_ready_fd() {
     this->max_fd_ = get_max_fd();
     // std::cout << CYAN << "max_fd: " << max_fd_ << RESET << std::endl;
     this->set_io_timeout(100);
+    // this->set_io_timeout(1000);
 	init_fds();
 
     Result<int, std::string> select_result = select_fds();

--- a/srcs/Server/Server.cpp
+++ b/srcs/Server/Server.cpp
@@ -397,11 +397,11 @@ void Server::update_fd_type_read_to_write(const EventPhase &event_state, int fd)
 
 
 void Server::delete_event(std::map<Fd, Event *>::iterator event) {
-    Event *client_session = event->second;
-    int client_fd = client_session->client_fd();
+    Event *client_event = event->second;
+    int client_fd = client_event->client_fd();
 
     this->fds_->clear_fd(client_fd);
-    delete client_session;
+    delete client_event;
     this->client_events_.erase(event);
 }
 


### PR DESCRIPTION
#90 forgetting to push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **バグ修正**
    - メモリ割り当て失敗に関連するエラーメッセージを改善しました。
    - `recv_size` の比較条件を調整しました。
    - エラーメッセージのデバッグ出力を強化しました。
- **リファクタ**
    - `execute_each_method` 内のメソッド呼び出し順序を再編成しました。
    - `exec_cgi` でイベントフェーズを `kExecuteCGI` に設定するためのメソッド呼び出しを追加しました。
    - タイムアウト値を 100 から 1000 に増加させました。
    - 変数名を明確化するために `delete_event` メソッドを修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->