### PR TITLE
Fix/status

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ NAME		=	webserv
 CXX			=	c++
 CXXFLAGS	=	-std=c++98 -Wall -Wextra -Werror -MMD -MP -pedantic
 #CXXFLAGS	+=	-g -fsanitize=address,undefined -fno-omit-frame-pointer
-#CXXFLAGS	+=	-D DEBUG
+CXXFLAGS	+=	-D DEBUG
 
 # SRCS -------------------------------------------------------------------------
 SRCS_DIR	=	srcs

--- a/conf/webserv.conf
+++ b/conf/webserv.conf
@@ -97,6 +97,12 @@ http {
             }
         }
 
+        # ----------------------------------------------------------------------
+        location /dir_a/ {      limit_except    GET POST { deny all; }
+                                root            html;
+                                index           a.html;
+                            client_max_body_size    20; } # location
+
         error_page      404                     /404.html;
         error_page      500  502  503  504      /50x.html;
         location = /50x.html {

--- a/html/index.html
+++ b/html/index.html
@@ -119,7 +119,7 @@
                 <button onclick="copyCommand('server_name_static')">copy</button>
                 <input type="text"
                        id="server_name_static"
-                       value="curl -i -H &quot;Host: webserv&quot; localhost:4242">
+                       value="curl -i -H &quot;Host: static_server&quot; localhost:4242">
             </div>
 
             <li> default server-1: localhost:4040 and nothing_server_name -> old_server or new_server✨
@@ -175,7 +175,7 @@
                 <button onclick="copyCommand('content_length_large')">copy</button>
                 <input type="text"
                        id="content_length_large"
-                       value="curl -i -H &quot;Content-Length: 2147483647&quot; localhost:4343/cgi-bin/post_simple.py">
+                       value="curl -i -H &quot;Content-Length: 2147483647&quot; --data &quot;less than INT_MAX&quot; localhost:4343/cgi-bin/post_simple.py">
             </div>
 
         </ul>

--- a/html/index.html
+++ b/html/index.html
@@ -107,28 +107,28 @@
     <li> curl command
         <ul>
             <li> server name: webserv (localhost:4242)
-            <div class="container">
-                <button onclick="copyCommand('server_name_webserv')">copy</button>
-                <input type="text"
-                       id="server_name_webserv"
-                       value="curl -i -H &quot;Host: webserv&quot; localhost:4242">
-            </div>
+                <div class="container">
+                    <button onclick="copyCommand('server_name_webserv')">copy</button>
+                    <input type="text"
+                           id="server_name_webserv"
+                           value="curl -i -H &quot;Host: webserv&quot; localhost:4242">
+                </div>
 
             <li> server name: static_server (localhost:4242)
-            <div class="container">
-                <button onclick="copyCommand('server_name_static')">copy</button>
-                <input type="text"
-                       id="server_name_static"
-                       value="curl -i -H &quot;Host: static_server&quot; localhost:4242">
-            </div>
+                <div class="container">
+                    <button onclick="copyCommand('server_name_static')">copy</button>
+                    <input type="text"
+                           id="server_name_static"
+                           value="curl -i -H &quot;Host: static_server&quot; localhost:4242">
+                </div>
 
             <li> default server-1: localhost:4040 and nothing_server_name -> old_server or new_server✨
-            <div class="container">
-                <button onclick="copyCommand('default_server_1')">copy</button>
-                <input type="text"
-                       id="default_server_1"
-                       value="curl -i -H &quot;Host: nothing_server_name&quot; localhost:4040">
-            </div>
+                <div class="container">
+                    <button onclick="copyCommand('default_server_1')">copy</button>
+                    <input type="text"
+                           id="default_server_1"
+                           value="curl -i -H &quot;Host: nothing_server_name&quot; localhost:4040">
+                </div>
 
             <li> default server-2: localhost:3939 and nothing_server_name -> server_a 🅰 or server_b
                 <div class="container">
@@ -147,20 +147,28 @@
                 </div>
 
             <li> GET method ignores request body
-            <div class="container">
-                <button onclick="copyCommand('ignore_body')">copy</button>
-                <input type="text"
-                       id="ignore_body"
-                       value="curl -i -X GET --data &quot;request body ignored&quot; localhost:4343/cgi-bin/post_simple.py">
-            </div>
+                <div class="container">
+                    <button onclick="copyCommand('ignore_body')">copy</button>
+                    <input type="text"
+                           id="ignore_body"
+                           value="curl -i -X GET --data &quot;request body ignored&quot; localhost:4343/cgi-bin/post_simple.py">
+                </div>
 
-            <li> Content larger than Content-Length
-            <div class="container">
-                <button onclick="copyCommand('large_content')">copy</button>
-                <input type="text"
-                       id="large_content"
-                       value="curl -i -X GET -H &quot;Content-Length: 1&quot; --data &quot;larger than 1&quot; localhost:4343/cgi-bin/post_simple.py">
-            </div>
+            <li> Content-Length too large (client_max_body_size < Content-Length)
+                <div class="container">
+                    <button onclick="copyCommand('content_length_large')">copy</button>
+                    <input type="text"
+                           id="content_length_large"
+                           value="curl -i -H &quot;Content-Length: 2147483647&quot; --data &quot;less than INT_MAX&quot; localhost:4343/cgi-bin/post_simple.py">
+                </div>
+
+            <li> Content larger than Content-Length ( Content-Length < recv body size )
+                <div class="container">
+                    <button onclick="copyCommand('large_content')">copy</button>
+                    <input type="text"
+                           id="large_content"
+                           value="curl -i -X GET -H &quot;Content-Length: 1&quot; --data &quot;larger than 1&quot; localhost:4343/cgi-bin/post_simple.py">
+                </div>
 
             <li> Content less than Content-Length -> connection closed by host
                 <div class="container">
@@ -170,13 +178,6 @@
                            value="curl -i -X GET -H &quot;Content-Length: 100&quot; --data &quot;less than 100&quot; localhost:4343/cgi-bin/post_simple.py">
                 </div>
 
-            <li> Content-Length too large by Length
-            <div class="container">
-                <button onclick="copyCommand('content_length_large')">copy</button>
-                <input type="text"
-                       id="content_length_large"
-                       value="curl -i -H &quot;Content-Length: 2147483647&quot; --data &quot;less than INT_MAX&quot; localhost:4343/cgi-bin/post_simple.py">
-            </div>
 
         </ul>
     <br>

--- a/srcs/Config/config_getter.cpp
+++ b/srcs/Config/config_getter.cpp
@@ -662,6 +662,7 @@ Result<std::size_t, int> Config::get_max_body_size(const ServerConfig &server_co
         return Result<std::size_t, int>::err(ERR);
     }
     LocationConfig location = location_result.ok_value();
+    // DEBUG_PRINT(RED, "max_body_size: %zu", location.max_body_size_bytes);
     return Result<std::size_t, int>::ok(location.max_body_size_bytes);
 }
 

--- a/srcs/Event/process_client_event.cpp
+++ b/srcs/Event/process_client_event.cpp
@@ -325,6 +325,11 @@ EventResult Event::get_host_config() {
 
 
 ProcResult Event::execute_each_method() {
+    if (this->response_->is_status_error()) {
+        DEBUG_PRINT(YELLOW, " exec_method 2 -> error_page");
+        return Success;
+    }
+
     if (this->response_->is_exec_cgi()) {
         return exec_cgi();
     } else {

--- a/srcs/HttpRequest/HttpRequest.cpp
+++ b/srcs/HttpRequest/HttpRequest.cpp
@@ -401,7 +401,7 @@ Result<ProcResult, StatusCode> HttpRequest::parse_body() {
     }
 
     std::size_t content_length = result.ok_value();
-    DEBUG_SERVER_PRINT("      ParseBody content-length: %zu", content_length);
+    DEBUG_SERVER_PRINT("      ParseBody content-length: %zu, max_body_size: %zu", content_length, this->request_max_body_size_);
 
     if (this->request_max_body_size_ < content_length) {
         DEBUG_SERVER_PRINT("      ParseBody max_body_size: %zu < content-length: %zu", this->request_max_body_size_, content_length);

--- a/srcs/HttpResponse/HttpResponse.cpp
+++ b/srcs/HttpResponse/HttpResponse.cpp
@@ -104,11 +104,6 @@ void HttpResponse::process_method_not_allowed() {
 
 ProcResult HttpResponse::exec_method() {
     DEBUG_PRINT(YELLOW, " exec_method 1 status(%d)", this->status_code());
-    if (is_status_error()) {
-        DEBUG_PRINT(YELLOW, " exec_method 2 -> error_page");
-        return Success;
-    }
-
     StatusCode status;
     switch (this->request_.method()) {
         case kGET:

--- a/srcs/HttpResponse/create_response_message.cpp
+++ b/srcs/HttpResponse/create_response_message.cpp
@@ -55,13 +55,14 @@ void HttpResponse::create_response_message() {
 
 bool HttpResponse::is_status_error() const {
     if (HttpMessageParser::is_status_client_error(this->status_code())) {
-        DEBUG_PRINT(MAGENTA, "is_status_error: %d: client error");
+        DEBUG_PRINT(MAGENTA, "is_status_error: %d: client error", this->status_code());
         return true;
     }
     if (HttpMessageParser::is_status_server_error(this->status_code())) {
-        DEBUG_PRINT(MAGENTA, "is_status_error: %d: server error");
+        DEBUG_PRINT(MAGENTA, "is_status_error: %d: server error", this->status_code());
         return true;
     }
+    DEBUG_PRINT(MAGENTA, "is_status_error: %d: not error -> continue", this->status_code());
     return false;
 }
 

--- a/test/integration/integration_test.conf
+++ b/test/integration/integration_test.conf
@@ -1,6 +1,8 @@
 # conf for integration test
 
 http {
+    recv_timeout        1s;  # original; combined client_header_timeout and client_body_timeout
+    send_timeout        1s;
     keepalive_timeout   0;  # 0: disable keep-alive
 
     server {    listen 4242;
@@ -35,8 +37,10 @@ http {
                                 index           a.html;
                                 client_max_body_size    20; } # location
         location /get_only/     { limit_except    GET    { deny all; } } # location
-        location /post_only/    { limit_except    POST   { deny all; } } # location
-        location /delete_only/  { limit_except    DELETE { deny all; } } # location
+        location /post_only/    { limit_except    POST   { deny all; }
+                                  client_max_body_size    20; } # location
+        location /delete_only/  { limit_except    DELETE { deny all; }
+                                  client_max_body_size    20; } # location
 
         location /upload/       { client_max_body_size    20M; } # location
 

--- a/test/integration/integration_test.conf
+++ b/test/integration/integration_test.conf
@@ -1,7 +1,7 @@
 # conf for integration test
 
 http {
-    recv_timeout        1s;  # original; combined client_header_timeout and client_body_timeout
+    recv_timeout        5s; # upload
     send_timeout        1s;
     keepalive_timeout   0;  # 0: disable keep-alive
 
@@ -38,11 +38,10 @@ http {
                                 client_max_body_size    20; } # location
         location /get_only/     { limit_except    GET    { deny all; } } # location
         location /post_only/    { limit_except    POST   { deny all; }
-                                  client_max_body_size    20; } # location
+                                  client_max_body_size    20; } # test
         location /delete_only/  { limit_except    DELETE { deny all; }
-                                  client_max_body_size    20; } # location
-
-        location /upload/       { client_max_body_size    20M; } # location
+                                  client_max_body_size    20; } # test
+        location /upload/       { client_max_body_size    20M; } # test
 
         error_page      404                     /404.html;
         error_page      500  502  503  504      /50x.html;

--- a/test/integration/test_err.sh
+++ b/test/integration/test_err.sh
@@ -55,10 +55,15 @@ expect_eq_get "$(echo -en "GET / HTTP/1.1 HTTP/1.1\r\nHost: host\r\n\r\n" | nc l
 
 
 # 411 Length Required
+#  no content-length but body exist -> 411
 expect_eq_get "$(echo -en "GET / HTTP/1.1\r\nHost: localhost\r\n\r\nlength required" | nc localhost 4242)"                    "411 Length Required"     ""
+expect_eq_get "$(echo -en "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"                | nc localhost 4242)"                    "200 OK"                  "html/index.html"
+
+expect_eq_get "$(echo -en "POST /post_only/ HTTP/1.1\r\nHost: localhost\r\n\r\nlength required" | nc localhost 4242)"         "411 Length Required"     ""
 
 
 # 413 payload too large
+#  large body -> close connection
 expect_eq_get "$(curl -isH "Content-Length: 1100000"  "localhost:4242/")"                                                     "413 Payload Too Large"    ""
 large=`python3 -c "print('a'*110000)"`
 expect_eq_get "$(curl -is -H "Content-Length: 1100" --data "$large" "Content-Length: 1100000"  "localhost:4242/")"            "413 Payload Too Large"    ""

--- a/test/integration/test_err.sh
+++ b/test/integration/test_err.sh
@@ -64,8 +64,13 @@ large=`python3 -c "print('a'*110000)"`
 expect_eq_get "$(curl -is -H "Content-Length: 1100" --data "$large" "Content-Length: 1100000"  "localhost:4242/")"            "413 Payload Too Large"    ""
 
 expect_eq_get "$(curl -is -H "Content-Length: 21"  "localhost:4242/dir_a/")"                                                  "413 Payload Too Large"    ""
-expect_eq_get "$(curl -i -X GET -H "Content-Length: 1" --data "ignored"  "localhost:4242/cgi-bin/post_simple.py")"            "413 Payload Too Large"    ""
-expect_eq_get "$(curl -is -H "Content-Length: 21"  -X GET --data "$(python3 -c "print('a'*21)")"  "localhost:4242/dir_a/")"   "413 Payload Too Large"    ""
+expect_eq_get "$(curl -is -X POST -H "Content-Length: 21"  "localhost:4242/post_only/")"                                      "413 Payload Too Large"    ""
+expect_eq_get "$(curl -is -X POST -H "Content-Length: 21"  "localhost:4242/delete_only/")"                                    "413 Payload Too Large"    ""
+
+expect_eq_get "$(curl -i -X GET  -H "Content-Length: 1" --data "ignored"  "localhost:4242/cgi-bin/post_simple.py")"           "413 Payload Too Large"    ""
+expect_eq_get "$(curl -i -X POST -H "Content-Length: 1" --data "ignored"  "localhost:4343/cgi-bin/post_simple.py")"           "413 Payload Too Large"    ""
+
+expect_eq_get "$(curl -is -X GET -H "Content-Length: 21"  --data "$(python3 -c "print('a'*21)")"  "localhost:4242/dir_a/")"   "413 Payload Too Large"    ""
 expect_eq_get "$(curl -is -X GET --data "$(python3 -c "print('a'*100)")"  "localhost:4242/dir_a/")"                           "413 Payload Too Large"    ""
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - `/dir_a/`のための新しい`location`ブロックを追加。メソッド制限、ルートディレクトリ、インデックスファイル、クライアントの最大ボディサイズが設定されています。
  - サーバー名と`curl`コマンドの値を、`Content-Length`の取り扱いに関する新しい例で更新しました。

- **バグ修正**
  - エラーステータスの確認後に特定のアクションを進める前にレスポンスステータスをチェックする条件を追加しました。
  - エラーステータスのチェックを削除して`Success`を返すように`exec_method`を修正しました。

- **ドキュメント**
  - `http`ブロックに`recv_timeout`と`send_timeout`の設定を追加しました。
  - `/post_only/`と`/delete_only/`の場所で`client_max_body_size`を修正し、コメント`# test`を追加しました。

- **テスト**
  - `411 Length Required`レスポンスの処理を追加しました。これは、コンテンツの長さなしにボディが存在する場合に発生します。
  - 大きなボディと特定のエンドポイントに対する`413 Payload Too Large`レスポンスの処理を追加しました。
  - 様々なシナリオで`413 Payload Too Large`レスポンスをトリガーするリクエストを修正しました。

- **リファクタ**
  - コンパイル時のデバッグ情報を含むために`DEBUG`フラグを`CXXFLAGS`に有効にしました。
  - `Config::get_max_body_size`関数のデバッグプリントステートメントをコメントアウトしました。
  - `max_body_size`パラメータを含むように`parse_body`の`DEBUG_SERVER_PRINT`ステートメントを修正しました。
  - `HttpResponse::is_status_error`のデバッグプリントステートメントを更新し、クライアントエラー、サーバーエラー、非エラーケースの`status_code`を含めました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->